### PR TITLE
Feat/utm settings

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -94,7 +94,7 @@ class Admin {
 			'bu_liaison_inquiry'
 		);
 
-		foreach (Settings::list_utm() as $name => $title) {
+		foreach (Settings::list_utm_titles() as $name => $title) {
 			$this->add_setting(
 				'bu_liaison_inquiry_admin_section_utm',
 				$name,

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -14,7 +14,7 @@ namespace BU\Plugins\Liaison_Inquiry;
  */
 class Admin {
 
-	private function add_setting( $section_name, $setting_name, $setting_title, $callback_name, $description='' ) {
+	private function add_setting( $section_name, $setting_name, $setting_title, $callback, $description='' ) {
 		$args = array(
 			'label_for' => $setting_name,
 			'class' => 'bu_liaison_inquiry_row',
@@ -28,7 +28,7 @@ class Admin {
 		add_settings_field(
 			$setting_name,
 			__( $setting_title, 'bu_liaison_inquiry' ),
-			array( $this, $callback_name ),
+			$callback,
 			'bu_liaison_inquiry',
 			$section_name,
 			$args
@@ -69,7 +69,9 @@ class Admin {
 			'bu_liaison_inquiry_admin_section_key',
 			'APIKey',
 			'API Key',
-			'apikey_callback',
+			function ( $args ) {
+				echo $this->setting_html_input( Settings::get('APIKey'), 50, $args );
+			},
 			'The API Key allows access to SpectrumEMP.'
 		);
 
@@ -77,7 +79,9 @@ class Admin {
 			'bu_liaison_inquiry_admin_section_key',
 			'ClientID',
 			'Client ID',
-			'clientid_callback',
+			function ( $args ) {
+				echo $this->setting_html_input( Settings::get('ClientID'), 10, $args );
+			},
 			'The Client ID specifies the organizational account.'
 		);
 
@@ -140,26 +144,6 @@ class Admin {
 	 */
 	function bu_liaison_inquiry_admin_section_key_callback( $args ) {
 		echo "<p id='" . esc_attr( $args['id'] ) . "'>" . esc_html__( 'Set the parameters for your organization to fetch the correct forms.', 'bu_liaison_inquiry' ) . '</p>';
-	}
-
-	/**
-	 * Outputs the form field for the API Key setting
-	 *
-	 * @param array $args Contains keys for label_for, class, bu_liaison_inquiry_custom_data,
-	 *                    and description (optional).
-	 */
-	function apikey_callback( $args ) {
-		echo $this->setting_html_input( Settings::get('APIKey'), 50, $args );
-	}
-
-	/**
-	 * Outputs the form field for the Client ID setting
-	 *
-	 * @param array $args Contains keys for label_for, class, bu_liaison_inquiry_custom_data,
-	 *                    and description (optional).
-	 */
-	function clientid_callback( $args ) {
-		echo $this->setting_html_input( Settings::get('ClientID'), 10, $args );
 	}
 
 	function bu_liaison_inquiry_admin_section_utm_callback( $args ) {

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -92,7 +92,7 @@ class Admin {
 	}
 
 	/**
-	 * Outputs the form field for the API Key, called by add_settings_field()
+	 * Outputs the form field for the API Key setting
 	 *
 	 * @param array $args Contains keys for label_for, class, bu_liaison_inquiry_custom_data.
 	 */
@@ -101,7 +101,7 @@ class Admin {
 	}
 
 	/**
-	 * Outputs the form field for the Client ID, called by add_settings_field()
+	 * Outputs the form field for the Client ID setting
 	 *
 	 * @param array $args Contains keys for label_for, class, bu_liaison_inquiry_custom_data.
 	 */

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -94,24 +94,8 @@ class Admin {
 	 *
 	 * @param array $args Contains keys for label_for, class, bu_liaison_inquiry_custom_data.
 	 */
-	function bu_liaison_inquiry_field_apikey_callback( $args ) {
-		// Get the value of the setting registered with register_setting().
-		$options = get_option( 'bu_liaison_inquiry_options' );
-
-		// Output the field.
-	?>
-	<input type="text" size="50" id="<?php echo esc_attr( $args['label_for'] ); ?>"
-			data-custom="<?php echo esc_attr( $args['bu_liaison_inquiry_custom_data'] ); ?>"
-			name="bu_liaison_inquiry_options[<?php echo esc_attr( $args['label_for'] ); ?>]"
-			value="<?php echo esc_html( $options['APIKey'] ); ?>"
-	>
-
-	<p class="description">
-		<?php echo esc_html( 'The API Key allows access to SpectrumEMP.', 'bu_liaison_inquiry' ); ?>
-	</p>
-
-
-	<?php
+	function apikey_callback( $args ) {
+		echo $this->setting_html_input( Settings::get('APIKey'), 50, $args );
 	}
 
 	/**
@@ -119,25 +103,11 @@ class Admin {
 	 *
 	 * @param array $args Contains keys for label_for, class, bu_liaison_inquiry_custom_data.
 	 */
-	function bu_liaison_inquiry_field_clientid_callback( $args ) {
-		// Get the value of the setting registered with register_setting().
-		$options = get_option( 'bu_liaison_inquiry_options' );
-
-		// Output the field.
-	?>
-	<input type="text" size="10" id="<?php echo esc_attr( $args['label_for'] ); ?>"
-			data-custom="<?php echo esc_attr( $args['bu_liaison_inquiry_custom_data'] ); ?>"
-			name="bu_liaison_inquiry_options[<?php echo esc_attr( $args['label_for'] ); ?>]"
-			value="<?php echo esc_html( $options['ClientID'] ); ?>"
-	>
-
-	<p class="description">
-		<?php echo esc_html( 'The Client ID specifies the organizational account.', 'bu_liaison_inquiry' ); ?>
-	</p>
-
-
-	<?php
+	function clientid_callback( $args ) {
+		echo $this->setting_html_input( Settings::get('ClientID'), 10, $args );
 	}
+
+
 	/**
 	 * Create an admin page.
 	 */

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -14,6 +14,42 @@ namespace BU\Plugins\Liaison_Inquiry;
  */
 class Admin {
 
+	private function add_setting( $section_name, $setting_name, $setting_title, $callback_name, $description='' ) {
+		$args = array(
+			'label_for' => $setting_name,
+			'class' => 'bu_liaison_inquiry_row',
+			'bu_liaison_inquiry_custom_data' => 'custom',
+		);
+
+		if ($description) {
+			$args['description'] = $description;
+		}
+
+		add_settings_field(
+			$setting_name,
+			__( $setting_title, 'bu_liaison_inquiry' ),
+			array( $this, $callback_name ),
+			'bu_liaison_inquiry',
+			$section_name,
+			$args
+		);
+	}
+
+	private function setting_html_input( $value, $size, $args ) {
+		$description = '';
+		if ( $args['description'] ) {
+			$esc_description = esc_html( $args['description'], 'bu_liaison_inquiry' );
+			$description = '<p class="description">' . $esc_description . '</p>';
+		}
+
+		return '<input' .
+		' type="text" size="' . esc_html($size) . '" id="' . esc_attr( $args['label_for'] ) . '"' .
+		' data-custom="' . esc_attr( $args['bu_liaison_inquiry_custom_data'] ) . '"' .
+		' name="bu_liaison_inquiry_options[' . esc_attr( $args['label_for'] ) . ']"' .
+		' value="' . esc_html( $value ) . '"' .
+		'>' . $description;
+	}
+
 	/**
 	 * Register the settings option and define the settings page
 	 */

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -110,6 +110,15 @@ class Admin {
 				}
 			);	
 		}
+
+		$this->add_setting(
+			'bu_liaison_inquiry_admin_section_utm',
+			'page_title',
+			'Page Title',
+			function ( $args ) {
+				echo $this->setting_html_input( Settings::get('page_title'), 10, $args );
+			}
+		);
 	}
 
 	/**

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -94,7 +94,8 @@ class Admin {
 	/**
 	 * Outputs the form field for the API Key setting
 	 *
-	 * @param array $args Contains keys for label_for, class, bu_liaison_inquiry_custom_data.
+	 * @param array $args Contains keys for label_for, class, bu_liaison_inquiry_custom_data,
+	 *                    and description (optional).
 	 */
 	function apikey_callback( $args ) {
 		echo $this->setting_html_input( Settings::get('APIKey'), 50, $args );
@@ -103,7 +104,8 @@ class Admin {
 	/**
 	 * Outputs the form field for the Client ID setting
 	 *
-	 * @param array $args Contains keys for label_for, class, bu_liaison_inquiry_custom_data.
+	 * @param array $args Contains keys for label_for, class, bu_liaison_inquiry_custom_data,
+	 *                    and description (optional).
 	 */
 	function clientid_callback( $args ) {
 		echo $this->setting_html_input( Settings::get('ClientID'), 10, $args );

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -61,7 +61,10 @@ class Admin {
 		add_settings_section(
 			'bu_liaison_inquiry_admin_section_key',
 			__( 'Enter SpectrumEMP API Key and Client ID', 'bu_liaison_inquiry' ),
-			array( $this, 'bu_liaison_inquiry_admin_section_key_callback' ),
+			function ( $args ) {
+				$escaped_description = esc_html__( 'Set the parameters for your organization to fetch the correct forms.', 'bu_liaison_inquiry' );
+				echo "<p id='" . esc_attr( $args['id'] ) . "'>" . $escaped_description . '</p>';
+			},
 			'bu_liaison_inquiry'
 		);
 
@@ -107,15 +110,6 @@ class Admin {
 				}
 			);	
 		}
-	}
-
-	/**
-	 * Outputs a section header for the admin page, called by add_settings_section()
-	 *
-	 * @param array $args Contains keys for title, id, callback.
-	 */
-	function bu_liaison_inquiry_admin_section_key_callback( $args ) {
-		echo "<p id='" . esc_attr( $args['id'] ) . "'>" . esc_html__( 'Set the parameters for your organization to fetch the correct forms.', 'bu_liaison_inquiry' ) . '</p>';
 	}
 
 	/**

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -113,10 +113,10 @@ class Admin {
 
 		$this->add_setting(
 			'bu_liaison_inquiry_admin_section_utm',
-			'page_title',
+			Settings::PAGE_TITLE_SETTING,
 			'Page Title',
 			function ( $args ) {
-				echo $this->setting_html_input( Settings::get('page_title'), 10, $args );
+				echo $this->setting_html_input( Settings::get(Settings::PAGE_TITLE_SETTING), 10, $args );
 			}
 		);
 	}

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -14,6 +14,15 @@ namespace BU\Plugins\Liaison_Inquiry;
  */
 class Admin {
 
+	/**
+	 * Wrapper for WP `add_settings_field`.
+	 *
+	 * @param string   $section_name Slug-name of the section, as in `add_settings_field`.
+	 * @param string   $setting_name Slug-name of the field, as in `add_settings_field`.
+	 * @param string   $setting_title Formatted fitle of the field, as in `add_settings_field`.
+	 * @param callable $callback Function that fills the field, as in `add_settings_field`.
+	 * @param string   $description (Optional) Text description of the field.
+	 */
 	private function add_setting( $section_name, $setting_name, $setting_title, $callback, $description = '' ) {
 		$args = array(
 			'label_for'                      => $setting_name,

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -57,7 +57,7 @@ class Admin {
 		// Register a new setting for "bu_liaison_inquiry" page.
 		register_setting( 'bu_liaison_inquiry', 'bu_liaison_inquiry_options' );
 
-		// Register a new section in the "bu_liaison_inquiry" page.
+		// Register the API Key and Client ID section.
 		add_settings_section(
 			'bu_liaison_inquiry_admin_section_key',
 			__( 'Enter SpectrumEMP API Key and Client ID', 'bu_liaison_inquiry' ),
@@ -65,32 +65,18 @@ class Admin {
 			'bu_liaison_inquiry'
 		);
 
-		// Register the API Key field.
-		add_settings_field(
-			'APIKey',
-			__( 'API Key', 'bu_liaison_inquiry' ),
-			array( $this, 'bu_liaison_inquiry_field_apikey_callback' ),
-			'bu_liaison_inquiry',
+		$this->add_setting(
 			'bu_liaison_inquiry_admin_section_key',
-			array(
-				'label_for' => 'APIKey',
-				'class' => 'bu_liaison_inquiry_row',
-				'bu_liaison_inquiry_custom_data' => 'custom',
-			)
+			'APIKey',
+			'API Key',
+			'apikey_callback'
 		);
 
-		// Register the ClientID field.
-		add_settings_field(
-			'ClientID',
-			__( 'Client ID', 'bu_liaison_inquiry' ),
-			array( $this, 'bu_liaison_inquiry_field_clientid_callback' ),
-			'bu_liaison_inquiry',
+		$this->add_setting(
 			'bu_liaison_inquiry_admin_section_key',
-			array(
-				'label_for' => 'ClientID',
-				'class' => 'bu_liaison_inquiry_row',
-				'bu_liaison_inquiry_custom_data' => 'custom',
-			)
+			'ClientID',
+			'Client ID',
+			'clientid_callback'
 		);
 	}
 

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -80,6 +80,57 @@ class Admin {
 			'clientid_callback',
 			'The Client ID specifies the organizational account.'
 		);
+
+
+		// Register the UTM Parameters section.
+		add_settings_section(
+			'bu_liaison_inquiry_admin_section_utm',
+			__( 'UTM Parameters', 'bu_liaison_inquiry' ),
+			array( $this, 'bu_liaison_inquiry_admin_section_utm_callback' ),
+			'bu_liaison_inquiry'
+		);
+
+		$this->add_setting(
+			'bu_liaison_inquiry_admin_section_utm',
+			'utm_source',
+			'Source',
+			'utm_source_callback'
+		);
+
+		$this->add_setting(
+			'bu_liaison_inquiry_admin_section_utm',
+			'utm_campaign',
+			'Campaign Name',
+			'utm_campaign_callback'
+		);
+
+		$this->add_setting(
+			'bu_liaison_inquiry_admin_section_utm',
+			'utm_content',
+			'Content',
+			'utm_content_callback'
+		);
+
+		$this->add_setting(
+			'bu_liaison_inquiry_admin_section_utm',
+			'utm_medium',
+			'Medium',
+			'utm_medium_callback'
+		);
+
+		$this->add_setting(
+			'bu_liaison_inquiry_admin_section_utm',
+			'utm_term',
+			'Term',
+			'utm_term_callback'
+		);
+
+		$this->add_setting(
+			'bu_liaison_inquiry_admin_section_utm',
+			'utm_page_subject',
+			'Landing Page Subject',
+			'utm_page_subject_callback'
+		);
 	}
 
 	/**
@@ -111,6 +162,33 @@ class Admin {
 		echo $this->setting_html_input( Settings::get('ClientID'), 10, $args );
 	}
 
+	function bu_liaison_inquiry_admin_section_utm_callback( $args ) {
+		echo "<p id='" . esc_attr( $args['id'] ) . "'>" . esc_html__( 'Specify Spectrum EMP field IDs associated with UTM parameters.', 'bu_liaison_inquiry' ) . '</p>';
+	}
+
+	function utm_source_callback( $args ) {
+		echo $this->setting_html_input( Settings::get('utm_source'), 10, $args );
+	}
+
+	function utm_campaign_callback( $args ) {
+		echo $this->setting_html_input( Settings::get('utm_campaign'), 10, $args );
+	}
+
+	function utm_content_callback( $args ) {
+		echo $this->setting_html_input( Settings::get('utm_content'), 10, $args );
+	}
+
+	function utm_medium_callback( $args ) {
+		echo $this->setting_html_input( Settings::get('utm_medium'), 10, $args );
+	}
+
+	function utm_term_callback( $args ) {
+		echo $this->setting_html_input( Settings::get('utm_term'), 10, $args );
+	}
+
+	function utm_page_subject_callback( $args ) {
+		echo $this->setting_html_input( Settings::get('utm_page_subject'), 10, $args );
+	}
 
 	/**
 	 * Create an admin page.

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -90,7 +90,10 @@ class Admin {
 		add_settings_section(
 			'bu_liaison_inquiry_admin_section_utm',
 			__( 'UTM Parameters', 'bu_liaison_inquiry' ),
-			array( $this, 'bu_liaison_inquiry_admin_section_utm_callback' ),
+			function ( $args ) {
+				$escaped_description = esc_html__( 'Specify Spectrum EMP field IDs associated with UTM parameters.', 'bu_liaison_inquiry' );
+				echo "<p id='" . esc_attr( $args['id'] ) . "'>" . $escaped_description . '</p>';
+			},
 			'bu_liaison_inquiry'
 		);
 
@@ -113,10 +116,6 @@ class Admin {
 	 */
 	function bu_liaison_inquiry_admin_section_key_callback( $args ) {
 		echo "<p id='" . esc_attr( $args['id'] ) . "'>" . esc_html__( 'Set the parameters for your organization to fetch the correct forms.', 'bu_liaison_inquiry' ) . '</p>';
-	}
-
-	function bu_liaison_inquiry_admin_section_utm_callback( $args ) {
-		echo "<p id='" . esc_attr( $args['id'] ) . "'>" . esc_html__( 'Specify Spectrum EMP field IDs associated with UTM parameters.', 'bu_liaison_inquiry' ) . '</p>';
 	}
 
 	/**

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -35,7 +35,15 @@ class Admin {
 		);
 	}
 
-	private function setting_html_input( $value, $size, $args ) {
+	/**
+	 * Generate HTML for the setting input with an optional description
+	 *
+	 * @param  string  $value Input's value or an empty string.
+	 * @param  integer $size  Input's size.
+	 * @param  array   $args  List of extra settings.
+	 * @return string Resulting HTML
+	 */
+	private function get_setting_html( $value, $size, $args ) {
 		$description = '';
 		if ( $args['description'] ) {
 			$esc_description = esc_html( $args['description'], 'bu_liaison_inquiry' );
@@ -73,7 +81,7 @@ class Admin {
 			'APIKey',
 			__( 'API Key', 'bu_liaison_inquiry' ),
 			function ( $args ) {
-				echo $this->setting_html_input( Settings::get( 'APIKey' ), 50, $args );
+				echo $this->get_setting_html( Settings::get( 'APIKey' ), 50, $args );
 			},
 			'The API Key allows access to SpectrumEMP.'
 		);
@@ -83,7 +91,7 @@ class Admin {
 			'ClientID',
 			__( 'Client ID', 'bu_liaison_inquiry' ),
 			function ( $args ) {
-				echo $this->setting_html_input( Settings::get( 'ClientID' ), 10, $args );
+				echo $this->get_setting_html( Settings::get( 'ClientID' ), 10, $args );
 			},
 			'The Client ID specifies the organizational account.'
 		);
@@ -105,7 +113,7 @@ class Admin {
 				$name,
 				$title,
 				function ( $args ) use ( $name ) {
-					echo $this->setting_html_input( Settings::get( $name ), 10, $args );
+					echo $this->get_setting_html( Settings::get( $name ), 10, $args );
 				}
 			);
 		}
@@ -115,7 +123,7 @@ class Admin {
 			Settings::PAGE_TITLE_SETTING,
 			__( 'Page Title', 'bu_liaison_inquiry' ),
 			function ( $args ) {
-				echo $this->setting_html_input( Settings::get( Settings::PAGE_TITLE_SETTING ), 10, $args );
+				echo $this->get_setting_html( Settings::get( Settings::PAGE_TITLE_SETTING ), 10, $args );
 			}
 		);
 	}

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -69,14 +69,16 @@ class Admin {
 			'bu_liaison_inquiry_admin_section_key',
 			'APIKey',
 			'API Key',
-			'apikey_callback'
+			'apikey_callback',
+			'The API Key allows access to SpectrumEMP.'
 		);
 
 		$this->add_setting(
 			'bu_liaison_inquiry_admin_section_key',
 			'ClientID',
 			'Client ID',
-			'clientid_callback'
+			'clientid_callback',
+			'The Client ID specifies the organizational account.'
 		);
 	}
 

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -14,14 +14,14 @@ namespace BU\Plugins\Liaison_Inquiry;
  */
 class Admin {
 
-	private function add_setting( $section_name, $setting_name, $setting_title, $callback, $description='' ) {
+	private function add_setting( $section_name, $setting_name, $setting_title, $callback, $description = '' ) {
 		$args = array(
-			'label_for' => $setting_name,
-			'class' => 'bu_liaison_inquiry_row',
+			'label_for'                      => $setting_name,
+			'class'                          => 'bu_liaison_inquiry_row',
 			'bu_liaison_inquiry_custom_data' => 'custom',
 		);
 
-		if ($description) {
+		if ( $description ) {
 			$args['description'] = $description;
 		}
 
@@ -39,11 +39,11 @@ class Admin {
 		$description = '';
 		if ( $args['description'] ) {
 			$esc_description = esc_html( $args['description'], 'bu_liaison_inquiry' );
-			$description = '<p class="description">' . $esc_description . '</p>';
+			$description     = '<p class="description">' . $esc_description . '</p>';
 		}
 
 		return '<input' .
-		' type="text" size="' . esc_html($size) . '" id="' . esc_attr( $args['label_for'] ) . '"' .
+		' type="text" size="' . esc_html( $size ) . '" id="' . esc_attr( $args['label_for'] ) . '"' .
 		' data-custom="' . esc_attr( $args['bu_liaison_inquiry_custom_data'] ) . '"' .
 		' name="bu_liaison_inquiry_options[' . esc_attr( $args['label_for'] ) . ']"' .
 		' value="' . esc_html( $value ) . '"' .
@@ -73,7 +73,7 @@ class Admin {
 			'APIKey',
 			'API Key',
 			function ( $args ) {
-				echo $this->setting_html_input( Settings::get('APIKey'), 50, $args );
+				echo $this->setting_html_input( Settings::get( 'APIKey' ), 50, $args );
 			},
 			'The API Key allows access to SpectrumEMP.'
 		);
@@ -83,11 +83,10 @@ class Admin {
 			'ClientID',
 			'Client ID',
 			function ( $args ) {
-				echo $this->setting_html_input( Settings::get('ClientID'), 10, $args );
+				echo $this->setting_html_input( Settings::get( 'ClientID' ), 10, $args );
 			},
 			'The Client ID specifies the organizational account.'
 		);
-
 
 		// Register the UTM Parameters section.
 		add_settings_section(
@@ -100,15 +99,15 @@ class Admin {
 			'bu_liaison_inquiry'
 		);
 
-		foreach (Settings::list_utm_titles() as $name => $title) {
+		foreach ( Settings::list_utm_titles() as $name => $title ) {
 			$this->add_setting(
 				'bu_liaison_inquiry_admin_section_utm',
 				$name,
 				$title,
 				function ( $args ) use ( $name ) {
-					echo $this->setting_html_input( Settings::get($name), 10, $args );
+					echo $this->setting_html_input( Settings::get( $name ), 10, $args );
 				}
-			);	
+			);
 		}
 
 		$this->add_setting(
@@ -116,7 +115,7 @@ class Admin {
 			Settings::PAGE_TITLE_SETTING,
 			'Page Title',
 			function ( $args ) {
-				echo $this->setting_html_input( Settings::get(Settings::PAGE_TITLE_SETTING), 10, $args );
+				echo $this->setting_html_input( Settings::get( Settings::PAGE_TITLE_SETTING ), 10, $args );
 			}
 		);
 	}

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -94,47 +94,16 @@ class Admin {
 			'bu_liaison_inquiry'
 		);
 
-		$this->add_setting(
-			'bu_liaison_inquiry_admin_section_utm',
-			'utm_source',
-			'Source',
-			'utm_source_callback'
-		);
-
-		$this->add_setting(
-			'bu_liaison_inquiry_admin_section_utm',
-			'utm_campaign',
-			'Campaign Name',
-			'utm_campaign_callback'
-		);
-
-		$this->add_setting(
-			'bu_liaison_inquiry_admin_section_utm',
-			'utm_content',
-			'Content',
-			'utm_content_callback'
-		);
-
-		$this->add_setting(
-			'bu_liaison_inquiry_admin_section_utm',
-			'utm_medium',
-			'Medium',
-			'utm_medium_callback'
-		);
-
-		$this->add_setting(
-			'bu_liaison_inquiry_admin_section_utm',
-			'utm_term',
-			'Term',
-			'utm_term_callback'
-		);
-
-		$this->add_setting(
-			'bu_liaison_inquiry_admin_section_utm',
-			'utm_page_subject',
-			'Landing Page Subject',
-			'utm_page_subject_callback'
-		);
+		foreach (Settings::list_utm() as $name => $title) {
+			$this->add_setting(
+				'bu_liaison_inquiry_admin_section_utm',
+				$name,
+				$title,
+				function ( $args ) use ( $name ) {
+					echo $this->setting_html_input( Settings::get($name), 10, $args );
+				}
+			);	
+		}
 	}
 
 	/**
@@ -148,30 +117,6 @@ class Admin {
 
 	function bu_liaison_inquiry_admin_section_utm_callback( $args ) {
 		echo "<p id='" . esc_attr( $args['id'] ) . "'>" . esc_html__( 'Specify Spectrum EMP field IDs associated with UTM parameters.', 'bu_liaison_inquiry' ) . '</p>';
-	}
-
-	function utm_source_callback( $args ) {
-		echo $this->setting_html_input( Settings::get('utm_source'), 10, $args );
-	}
-
-	function utm_campaign_callback( $args ) {
-		echo $this->setting_html_input( Settings::get('utm_campaign'), 10, $args );
-	}
-
-	function utm_content_callback( $args ) {
-		echo $this->setting_html_input( Settings::get('utm_content'), 10, $args );
-	}
-
-	function utm_medium_callback( $args ) {
-		echo $this->setting_html_input( Settings::get('utm_medium'), 10, $args );
-	}
-
-	function utm_term_callback( $args ) {
-		echo $this->setting_html_input( Settings::get('utm_term'), 10, $args );
-	}
-
-	function utm_page_subject_callback( $args ) {
-		echo $this->setting_html_input( Settings::get('utm_page_subject'), 10, $args );
 	}
 
 	/**

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -27,7 +27,7 @@ class Admin {
 
 		add_settings_field(
 			$setting_name,
-			__( $setting_title, 'bu_liaison_inquiry' ),
+			$setting_title,
 			$callback,
 			'bu_liaison_inquiry',
 			$section_name,
@@ -71,7 +71,7 @@ class Admin {
 		$this->add_setting(
 			'bu_liaison_inquiry_admin_section_key',
 			'APIKey',
-			'API Key',
+			__( 'API Key', 'bu_liaison_inquiry' ),
 			function ( $args ) {
 				echo $this->setting_html_input( Settings::get( 'APIKey' ), 50, $args );
 			},
@@ -81,7 +81,7 @@ class Admin {
 		$this->add_setting(
 			'bu_liaison_inquiry_admin_section_key',
 			'ClientID',
-			'Client ID',
+			__( 'Client ID', 'bu_liaison_inquiry' ),
 			function ( $args ) {
 				echo $this->setting_html_input( Settings::get( 'ClientID' ), 10, $args );
 			},
@@ -113,7 +113,7 @@ class Admin {
 		$this->add_setting(
 			'bu_liaison_inquiry_admin_section_utm',
 			Settings::PAGE_TITLE_SETTING,
-			'Page Title',
+			__( 'Page Title', 'bu_liaison_inquiry' ),
 			function ( $args ) {
 				echo $this->setting_html_input( Settings::get( Settings::PAGE_TITLE_SETTING ), 10, $args );
 			}

--- a/includes/class-inquiry-form.php
+++ b/includes/class-inquiry-form.php
@@ -74,31 +74,21 @@ class Inquiry_Form {
 			$inquiry_form = $this->minify_form_definition( $inquiry_form, $attrs );
 		}
 
-		$inquiry_form = $this->hide_utm_parameters( $inquiry_form, Settings::list_utm_values(), function ( $parameter_name ) {
+		$inquiry_form = $this->autofill_parameters( $inquiry_form, Settings::list_utm_values(), function ( $parameter_name ) {
 			if ( isset( $_GET[$parameter_name] ) ) {
 				return $_GET[$parameter_name];
 			}
 			return '';
 		} );
 
-		$inquiry_form = $this->hide_page_title( $inquiry_form, Settings::page_title_value(), get_the_title() );
+		$inquiry_form = $this->autofill_parameters( $inquiry_form, Settings::page_title_values(), function ( $parameter_name ) {
+			return get_the_title();
+		} );
 
 		return $this->render_template( $inquiry_form, $form_id );
 	}
 
-	public function hide_page_title ( $inquiry_form, $title_field_id, $page_title ) {
-		foreach ( $inquiry_form->sections as $section ) {
-			foreach ( $section->fields as $field_key => $field ) {
-				if ( $field->id == $title_field_id ) {
-					$field->hidden = true;
-					$field->hidden_value = $page_title;
-				}
-			}
-		}
-		return $inquiry_form;
-	}
-
-	public function hide_utm_parameters( $inquiry_form, $auto_list, $callback ) {
+	public function autofill_parameters( $inquiry_form, $auto_list, $callback ) {
 		foreach ( $inquiry_form->sections as $section ) {
 			foreach ( $section->fields as $field_key => $field ) {
 				if ( in_array($field->id, $auto_list) ) {

--- a/includes/class-inquiry-form.php
+++ b/includes/class-inquiry-form.php
@@ -74,6 +74,13 @@ class Inquiry_Form {
 			$inquiry_form = $this->minify_form_definition( $inquiry_form, $attrs );
 		}
 
+		$inquiry_form = $this->hide_utm_parameters( $inquiry_form, Settings::list_utm_values(), function ( $parameter_name ) {
+			if ( isset( $_GET[$parameter_name] ) ) {
+				return $_GET[$parameter_name];
+			}
+			return '';
+		} );
+
 		$inquiry_form = $this->hide_page_title( $inquiry_form, Settings::page_title_value(), get_the_title() );
 
 		return $this->render_template( $inquiry_form, $form_id );
@@ -85,6 +92,18 @@ class Inquiry_Form {
 				if ( $field->id == $title_field_id ) {
 					$field->hidden = true;
 					$field->hidden_value = $page_title;
+				}
+			}
+		}
+		return $inquiry_form;
+	}
+
+	public function hide_utm_parameters( $inquiry_form, $auto_list, $callback ) {
+		foreach ( $inquiry_form->sections as $section ) {
+			foreach ( $section->fields as $field_key => $field ) {
+				if ( in_array($field->id, $auto_list) ) {
+					$field->hidden = true;
+					$field->hidden_value = $callback( array_search( $field->id, $auto_list ) );
 				}
 			}
 		}

--- a/includes/class-inquiry-form.php
+++ b/includes/class-inquiry-form.php
@@ -99,9 +99,9 @@ class Inquiry_Form {
 	 *
 	 * @param  \stdClass $form_definition Original form definition.
 	 * @param  array     $auto_list List of fields that need to be pre-filled;
-	 *                   format: [(string)'Field ID' => (string)'field_name'].
+	 *                              format: [(string)'Field ID' => (string)'field_name'].
 	 * @param  callable  $callback Function accepting field_name as the argument
-	 *                   and returning field's pre-filled value.
+	 *                             and returning field's pre-filled value.
 	 * @return \stdClass Modified form definition
 	 */
 	public function autofill_fields( $form_definition, $auto_list, $callback ) {

--- a/includes/class-inquiry-form.php
+++ b/includes/class-inquiry-form.php
@@ -75,16 +75,20 @@ class Inquiry_Form {
 			$inquiry_form = $this->minify_form_definition( $inquiry_form, $attrs );
 		}
 
-		$inquiry_form = $this->autofill_parameters( $inquiry_form, Settings::list_utm_values(), function ( $parameter_name ) {
-			if ( isset( $_GET[$parameter_name] ) ) {
-				return $_GET[$parameter_name];
+		$inquiry_form = $this->autofill_parameters(
+			$inquiry_form, Settings::list_utm_values(), function ( $parameter_name ) {
+				if ( isset( $_GET[ $parameter_name ] ) ) {
+					return $_GET[ $parameter_name ];
+				}
+				return '';
 			}
-			return '';
-		} );
+		);
 
-		$inquiry_form = $this->autofill_parameters( $inquiry_form, Settings::page_title_values(), function ( $parameter_name ) {
-			return get_the_title();
-		} );
+		$inquiry_form = $this->autofill_parameters(
+			$inquiry_form, Settings::page_title_values(), function ( $parameter_name ) {
+				return get_the_title();
+			}
+		);
 
 		return $this->render_template( $inquiry_form, $form_id );
 	}
@@ -92,8 +96,8 @@ class Inquiry_Form {
 	public function autofill_parameters( $inquiry_form, $auto_list, $callback ) {
 		foreach ( $inquiry_form->sections as $section ) {
 			foreach ( $section->fields as $field_key => $field ) {
-				if ( in_array($field->id, $auto_list) ) {
-					$field->hidden = true;
+				if ( in_array( $field->id, $auto_list ) ) {
+					$field->hidden       = true;
 					$field->hidden_value = $callback( array_search( $field->id, $auto_list ) );
 				}
 			}

--- a/includes/class-inquiry-form.php
+++ b/includes/class-inquiry-form.php
@@ -74,7 +74,21 @@ class Inquiry_Form {
 			$inquiry_form = $this->minify_form_definition( $inquiry_form, $attrs );
 		}
 
+		$inquiry_form = $this->hide_page_title( $inquiry_form, Settings::page_title_value(), get_the_title() );
+
 		return $this->render_template( $inquiry_form, $form_id );
+	}
+
+	public function hide_page_title ( $inquiry_form, $title_field_id, $page_title ) {
+		foreach ( $inquiry_form->sections as $section ) {
+			foreach ( $section->fields as $field_key => $field ) {
+				if ( $field->id == $title_field_id ) {
+					$field->hidden = true;
+					$field->hidden_value = $page_title;
+				}
+			}
+		}
+		return $inquiry_form;
 	}
 
 	/**

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -35,9 +35,8 @@ class Plugin {
 	 */
 	public function get_api_instance() {
 		// Get API key and Client ID from option settings.
-		$options = get_option( 'bu_liaison_inquiry_options' );
-		$client_id = $options['ClientID'];
-		$api_key = $options['APIKey'];
+		$client_id = Settings::get('ClientID');
+		$api_key = Settings::get('APIKey');
 
 		$class = $this->api_class;
 

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -35,8 +35,8 @@ class Plugin {
 	 */
 	public function get_api_instance() {
 		// Get API key and Client ID from option settings.
-		$client_id = Settings::get('ClientID');
-		$api_key = Settings::get('APIKey');
+		$client_id = Settings::get( 'ClientID' );
+		$api_key   = Settings::get( 'APIKey' );
 
 		$class = $this->api_class;
 

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -14,10 +14,8 @@ namespace BU\Plugins\Liaison_Inquiry;
  */
 class Settings {
 
-	const NAME                = 'bu_liaison_inquiry_options';
-	const PAGE_TITLE_SETTING  = 'page_title';
-	const UTM_SETTINGS        = array( 'utm_source', 'utm_campaign', 'utm_content', 'utm_medium', 'utm_term' );
-	const UTM_SETTINGS_TITLES = array( 'Source', 'Campaign Name', 'Content', 'Medium', 'Term' );
+	const NAME               = 'bu_liaison_inquiry_options';
+	const PAGE_TITLE_SETTING = 'page_title';
 
 	static function get( $setting_name ) {
 		$options = get_option( self::NAME );
@@ -34,11 +32,13 @@ class Settings {
 	}
 
 	static function list_utm_titles() {
-		$result = array();
-		foreach ( self::UTM_SETTINGS as $index => $setting_name ) {
-			$result[ $setting_name ] = self::UTM_SETTINGS_TITLES[ $index ];
-		}
-		return $result;
+		return [
+			'utm_source'   => __( 'Source', 'bu_liaison_inquiry' ),
+			'utm_campaign' => __( 'Campaign Name', 'bu_liaison_inquiry' ),
+			'utm_content'  => __( 'Content', 'bu_liaison_inquiry' ),
+			'utm_medium'   => __( 'Medium', 'bu_liaison_inquiry' ),
+			'utm_term'     => __( 'Term', 'bu_liaison_inquiry' ),
+		];
 	}
 
 	static function list_utm_values() {

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -15,8 +15,8 @@ namespace BU\Plugins\Liaison_Inquiry;
 class Settings {
 
     const NAME = 'bu_liaison_inquiry_options';
-    const UTM_SETTINGS = array('utm_source', 'utm_campaign', 'utm_content', 'utm_medium', 'utm_term', 'utm_page_subject');
-    const UTM_SETTINGS_TITLES = array('Source', 'Campaign Name', 'Content', 'Medium', 'Term', 'Landing Page Subject');
+    const UTM_SETTINGS = array('utm_source', 'utm_campaign', 'utm_content', 'utm_medium', 'utm_term');
+    const UTM_SETTINGS_TITLES = array('Source', 'Campaign Name', 'Content', 'Medium', 'Term');
 
     static function get( $setting_name ) {
         $options = get_option( self::NAME );

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -15,6 +15,8 @@ namespace BU\Plugins\Liaison_Inquiry;
 class Settings {
 
     const NAME = 'bu_liaison_inquiry_options';
+    const UTM_SETTINGS = array('utm_source', 'utm_campaign', 'utm_content', 'utm_medium', 'utm_term', 'utm_page_subject');
+    const UTM_SETTINGS_TITLES = array('Source', 'Campaign Name', 'Content', 'Medium', 'Term', 'Landing Page Subject');
 
     static function get( $setting_name ) {
         $options = get_option( self::NAME );
@@ -30,4 +32,11 @@ class Settings {
         return $options[$setting_name];
     }
 
+    static function list_utm() {
+        $result = array();
+        foreach (self::UTM_SETTINGS as $index => $setting_name) {
+            $result[$setting_name] = SELF::UTM_SETTINGS_TITLES[$index];
+        }
+        return $result;
+    }
 }

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -14,8 +14,10 @@ namespace BU\Plugins\Liaison_Inquiry;
  */
 class Settings {
 
-	const NAME               = 'bu_liaison_inquiry_options';
-	const PAGE_TITLE_SETTING = 'page_title';
+	const NAME                = 'bu_liaison_inquiry_options';
+	const PAGE_TITLE_SETTING  = 'page_title';
+	const UTM_SETTINGS        = array( 'utm_source', 'utm_campaign', 'utm_content', 'utm_medium', 'utm_term' );
+	const UTM_SETTINGS_TITLES = array( 'Source', 'Campaign Name', 'Content', 'Medium', 'Term' );
 
 	static function get( $setting_name ) {
 		$options = get_option( self::NAME );
@@ -32,13 +34,11 @@ class Settings {
 	}
 
 	static function list_utm_titles() {
-		return [
-			'utm_source'   => __( 'Source', 'bu_liaison_inquiry' ),
-			'utm_campaign' => __( 'Campaign Name', 'bu_liaison_inquiry' ),
-			'utm_content'  => __( 'Content', 'bu_liaison_inquiry' ),
-			'utm_medium'   => __( 'Medium', 'bu_liaison_inquiry' ),
-			'utm_term'     => __( 'Term', 'bu_liaison_inquiry' ),
-		];
+		$result = array();
+		foreach ( self::UTM_SETTINGS as $index => $setting_name ) {
+			$result[ $setting_name ] = self::UTM_SETTINGS_TITLES[ $index ];
+		}
+		return $result;
 	}
 
 	static function list_utm_values() {

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -18,12 +18,6 @@ class Settings {
 	const PAGE_TITLE_SETTING = 'page_title';
 	const UTM_SETTINGS       = array( 'utm_source', 'utm_campaign', 'utm_content', 'utm_medium', 'utm_term' );
 
-	static function page_title_values() {
-		$result                             = array();
-		$result[ self::PAGE_TITLE_SETTING ] = self::get( self::PAGE_TITLE_SETTING );
-		return $result;
-	}
-
 	static function list_utm_titles() {
 		$titles = [
 			__( 'Source', 'bu_liaison_inquiry' ),
@@ -61,6 +55,12 @@ class Settings {
 				$result[ $setting_name ] = $value;
 			}
 		}
+		return $result;
+	}
+
+	static function page_title_values() {
+		$result                             = array();
+		$result[ self::PAGE_TITLE_SETTING ] = self::get( self::PAGE_TITLE_SETTING );
 		return $result;
 	}
 }

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -41,6 +41,17 @@ class Settings {
         return $result;
     }
 
+    static function list_utm_values() {
+        $result = array();
+        foreach (self::UTM_SETTINGS as $index => $setting_name) {
+            $value = self::get( $setting_name );
+            if ( $value ) {
+                $result[$setting_name] = $value;
+            }
+        }
+        return $result;
+    }
+
     static function page_title_value() {
         return self::get( self::PAGE_TITLE_SETTING );
     }

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -14,47 +14,47 @@ namespace BU\Plugins\Liaison_Inquiry;
  */
 class Settings {
 
-    const NAME = 'bu_liaison_inquiry_options';
-    const PAGE_TITLE_SETTING = 'page_title';
-    const UTM_SETTINGS = array('utm_source', 'utm_campaign', 'utm_content', 'utm_medium', 'utm_term');
-    const UTM_SETTINGS_TITLES = array('Source', 'Campaign Name', 'Content', 'Medium', 'Term');
+	const NAME                = 'bu_liaison_inquiry_options';
+	const PAGE_TITLE_SETTING  = 'page_title';
+	const UTM_SETTINGS        = array( 'utm_source', 'utm_campaign', 'utm_content', 'utm_medium', 'utm_term' );
+	const UTM_SETTINGS_TITLES = array( 'Source', 'Campaign Name', 'Content', 'Medium', 'Term' );
 
-    static function get( $setting_name ) {
-        $options = get_option( self::NAME );
+	static function get( $setting_name ) {
+		$options = get_option( self::NAME );
 
-        if ( !$options ) {
-            return '';
-        }
+		if ( ! $options ) {
+			return '';
+		}
 
-        if ( !array_key_exists( $setting_name, $options ) ) {
-            return '';
-        }
+		if ( ! array_key_exists( $setting_name, $options ) ) {
+			return '';
+		}
 
-        return $options[$setting_name];
-    }
+		return $options[ $setting_name ];
+	}
 
-    static function list_utm_titles() {
-        $result = array();
-        foreach (self::UTM_SETTINGS as $index => $setting_name) {
-            $result[$setting_name] = SELF::UTM_SETTINGS_TITLES[$index];
-        }
-        return $result;
-    }
+	static function list_utm_titles() {
+		$result = array();
+		foreach ( self::UTM_SETTINGS as $index => $setting_name ) {
+			$result[ $setting_name ] = self::UTM_SETTINGS_TITLES[ $index ];
+		}
+		return $result;
+	}
 
-    static function list_utm_values() {
-        $result = array();
-        foreach (self::UTM_SETTINGS as $index => $setting_name) {
-            $value = self::get( $setting_name );
-            if ( $value ) {
-                $result[$setting_name] = $value;
-            }
-        }
-        return $result;
-    }
+	static function list_utm_values() {
+		$result = array();
+		foreach ( self::UTM_SETTINGS as $index => $setting_name ) {
+			$value = self::get( $setting_name );
+			if ( $value ) {
+				$result[ $setting_name ] = $value;
+			}
+		}
+		return $result;
+	}
 
-    static function page_title_values( $default_value ) {
-        $result = array();
-        $result[self::PAGE_TITLE_SETTING] = self::get( self::PAGE_TITLE_SETTING );
-        return $result;
-    }
+	static function page_title_values( $default_value ) {
+		$result                             = array();
+		$result[ self::PAGE_TITLE_SETTING ] = self::get( self::PAGE_TITLE_SETTING );
+		return $result;
+	}
 }

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Collection of static method retrieving current settings
+ *
+ * @package BU_Liaison_Inquiry
+ */
+
+namespace BU\Plugins\Liaison_Inquiry;
+
+/**
+ * Settings class.
+ *
+ * Allows to easily retrieve saved settings.
+ */
+class Settings {
+
+    const NAME = 'bu_liaison_inquiry_options';
+
+    static function get( $setting_name ) {
+        $options = get_option( self::NAME );
+        // TODO: check if setting exists before retrieving it
+        return $options[$setting_name];
+    }
+
+}

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -32,7 +32,7 @@ class Settings {
         return $options[$setting_name];
     }
 
-    static function list_utm() {
+    static function list_utm_titles() {
         $result = array();
         foreach (self::UTM_SETTINGS as $index => $setting_name) {
             $result[$setting_name] = SELF::UTM_SETTINGS_TITLES[$index];

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -52,7 +52,9 @@ class Settings {
         return $result;
     }
 
-    static function page_title_value() {
-        return self::get( self::PAGE_TITLE_SETTING );
+    static function page_title_values( $default_value ) {
+        $result = array();
+        $result[self::PAGE_TITLE_SETTING] = self::get( self::PAGE_TITLE_SETTING );
+        return $result;
     }
 }

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -15,6 +15,7 @@ namespace BU\Plugins\Liaison_Inquiry;
 class Settings {
 
     const NAME = 'bu_liaison_inquiry_options';
+    const PAGE_TITLE_SETTING = 'page_title';
     const UTM_SETTINGS = array('utm_source', 'utm_campaign', 'utm_content', 'utm_medium', 'utm_term');
     const UTM_SETTINGS_TITLES = array('Source', 'Campaign Name', 'Content', 'Medium', 'Term');
 
@@ -38,5 +39,9 @@ class Settings {
             $result[$setting_name] = SELF::UTM_SETTINGS_TITLES[$index];
         }
         return $result;
+    }
+
+    static function page_title_value() {
+        return self::get( self::PAGE_TITLE_SETTING );
     }
 }

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -18,7 +18,15 @@ class Settings {
 
     static function get( $setting_name ) {
         $options = get_option( self::NAME );
-        // TODO: check if setting exists before retrieving it
+
+        if ( !$options ) {
+            return '';
+        }
+
+        if ( !array_key_exists( $setting_name, $options ) ) {
+            return '';
+        }
+
         return $options[$setting_name];
     }
 

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -14,10 +14,30 @@ namespace BU\Plugins\Liaison_Inquiry;
  */
 class Settings {
 
-	const NAME                = 'bu_liaison_inquiry_options';
-	const PAGE_TITLE_SETTING  = 'page_title';
-	const UTM_SETTINGS        = array( 'utm_source', 'utm_campaign', 'utm_content', 'utm_medium', 'utm_term' );
-	const UTM_SETTINGS_TITLES = array( 'Source', 'Campaign Name', 'Content', 'Medium', 'Term' );
+	const NAME               = 'bu_liaison_inquiry_options';
+	const PAGE_TITLE_SETTING = 'page_title';
+	const UTM_SETTINGS       = array( 'utm_source', 'utm_campaign', 'utm_content', 'utm_medium', 'utm_term' );
+
+	static function page_title_values() {
+		$result                             = array();
+		$result[ self::PAGE_TITLE_SETTING ] = self::get( self::PAGE_TITLE_SETTING );
+		return $result;
+	}
+
+	static function list_utm_titles() {
+		$titles = [
+			__( 'Source', 'bu_liaison_inquiry' ),
+			__( 'Campaign Name', 'bu_liaison_inquiry' ),
+			__( 'Content', 'bu_liaison_inquiry' ),
+			__( 'Medium', 'bu_liaison_inquiry' ),
+			__( 'Term', 'bu_liaison_inquiry' ),
+		];
+		$result = array();
+		foreach ( self::UTM_SETTINGS as $index => $setting_name ) {
+			$result[ $setting_name ] = $titles[ $index ];
+		}
+		return $result;
+	}
 
 	static function get( $setting_name ) {
 		$options = get_option( self::NAME );
@@ -33,14 +53,6 @@ class Settings {
 		return $options[ $setting_name ];
 	}
 
-	static function list_utm_titles() {
-		$result = array();
-		foreach ( self::UTM_SETTINGS as $index => $setting_name ) {
-			$result[ $setting_name ] = self::UTM_SETTINGS_TITLES[ $index ];
-		}
-		return $result;
-	}
-
 	static function list_utm_values() {
 		$result = array();
 		foreach ( self::UTM_SETTINGS as $index => $setting_name ) {
@@ -49,12 +61,6 @@ class Settings {
 				$result[ $setting_name ] = $value;
 			}
 		}
-		return $result;
-	}
-
-	static function page_title_values( $default_value ) {
-		$result                             = array();
-		$result[ self::PAGE_TITLE_SETTING ] = self::get( self::PAGE_TITLE_SETTING );
 		return $result;
 	}
 }

--- a/tests/test-class-inquiry-form.php
+++ b/tests/test-class-inquiry-form.php
@@ -25,6 +25,21 @@ class BU_Liaison_Inquiry_Test_Inquiry_Form extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Generate sample form definition
+	 *
+	 * @return \stdClass Sample form definition
+	 */
+	private function mock_form_definition() {
+		$form_definition                             = new \stdClass();
+		$form_definition->sections                   = [];
+		$form_definition->sections[0]                = new \stdClass();
+		$form_definition->sections[0]->fields[0]     = new \stdClass();
+		$form_definition->sections[0]->fields[0]->id = 1;
+
+		return $form_definition;
+	}
+
+	/**
 	 * Call the method two times, with and without attributes, and check that
 	 * it doesn't try to minify form definition when no attributes were passed
 	 *
@@ -41,14 +56,22 @@ class BU_Liaison_Inquiry_Test_Inquiry_Form extends WP_UnitTestCase {
 				'form_id' => $form_id,
 			]
 		);
-		$form_definition                  = 'form_definition coming from api, non-default form';
-		$form_definition_default          = 'form_definition coming from api, default form';
-		$minified_form_definition         = 'minified form definition, non-default form';
-		$minified_form_definition_default = 'minified form definition, default form';
 		$form_html                        = 'html response, non-default form';
 		$form_html_default                = 'html response, default form';
 		$form_html_mini                   = 'html response mini, non-default form';
 		$form_html_mini_default           = 'html response mini, default form';
+
+		// Mock form_definition coming from api, non-default form.
+		$form_definition = $this->mock_form_definition();
+
+		// Mock form_definition coming from api, default form.
+		$form_definition_default = $this->mock_form_definition();
+
+		// Mock minified form definition, non-default form.
+		$minified_form_definition = $this->mock_form_definition();
+
+		// Mock minified form definition, default form.
+		$minified_form_definition_default = $this->mock_form_definition();
 
 		$form = $this->getMockBuilder( Inquiry_Form::class )
 						->setConstructorArgs( [ $this->spectrum ] )

--- a/tests/test-class-inquiry-form.php
+++ b/tests/test-class-inquiry-form.php
@@ -30,11 +30,26 @@ class BU_Liaison_Inquiry_Test_Inquiry_Form extends WP_UnitTestCase {
 	 * @return \stdClass Sample form definition
 	 */
 	private function mock_form_definition() {
-		$form_definition                             = new \stdClass();
-		$form_definition->sections                   = [];
-		$form_definition->sections[0]                = new \stdClass();
-		$form_definition->sections[0]->fields[0]     = new \stdClass();
-		$form_definition->sections[0]->fields[0]->id = 1;
+		$field_1           = new stdClass();
+		$field_1->id       = '1';
+		$field_1->required = '1';
+
+		$field_2           = new stdClass();
+		$field_2->id       = '2';
+		$field_2->required = '0';
+
+		$field_3           = new stdClass();
+		$field_3->id       = '3';
+		$field_3->required = '1';
+
+		$field_4           = new stdClass();
+		$field_4->id       = '4';
+		$field_4->required = '1';
+
+		$form_section              = new stdClass();
+		$form_section->fields      = [ $field_1, $field_2, $field_3, $field_4 ];
+		$form_definition           = new stdClass();
+		$form_definition->sections = [ $form_section ];
 
 		return $form_definition;
 	}
@@ -141,26 +156,7 @@ class BU_Liaison_Inquiry_Test_Inquiry_Form extends WP_UnitTestCase {
 	 * @covers BU\Plugins\Liaison_Inquiry\Inquiry_Form::minify_form_definition
 	 */
 	public function test_minify_form_definition() {
-		$field_1           = new stdClass();
-		$field_1->id       = '1';
-		$field_1->required = '1';
-
-		$field_2           = new stdClass();
-		$field_2->id       = '2';
-		$field_2->required = '0';
-
-		$field_3           = new stdClass();
-		$field_3->id       = '3';
-		$field_3->required = '1';
-
-		$field_4           = new stdClass();
-		$field_4->id       = '4';
-		$field_4->required = '1';
-
-		$form_section              = new stdClass();
-		$form_section->fields      = [ $field_1, $field_2, $field_3, $field_4 ];
-		$form_definition           = new stdClass();
-		$form_definition->sections = [ $form_section ];
+		$form_definition = $this->mock_form_definition();
 
 		$attributes = array(
 			'fields' => '1,4',

--- a/tests/test-class-inquiry-form.php
+++ b/tests/test-class-inquiry-form.php
@@ -64,9 +64,10 @@ class BU_Liaison_Inquiry_Test_Inquiry_Form extends WP_UnitTestCase {
 		$default_form_id = null;
 		$form_id         = 'form_id';
 
-		$shortcode_attributes           = [
+		$shortcode_attributes = [
 			'some' => 'value',
 		];
+
 		$shortcode_attributes_with_form = array_merge(
 			$shortcode_attributes, [
 				'form_id' => $form_id,

--- a/tests/test-class-inquiry-form.php
+++ b/tests/test-class-inquiry-form.php
@@ -46,32 +46,27 @@ class BU_Liaison_Inquiry_Test_Inquiry_Form extends WP_UnitTestCase {
 	 * @covers BU\Plugins\Liaison_Inquiry\Inquiry_Form::get_html
 	 */
 	public function test_get_html() {
-		$default_form_id                  = null;
-		$form_id                          = 'form_id';
-		$shortcode_attributes             = [
+		$default_form_id = null;
+		$form_id         = 'form_id';
+
+		$shortcode_attributes           = [
 			'some' => 'value',
 		];
-		$shortcode_attributes_with_form   = array_merge(
+		$shortcode_attributes_with_form = array_merge(
 			$shortcode_attributes, [
 				'form_id' => $form_id,
 			]
 		);
-		$form_html                        = 'html response, non-default form';
-		$form_html_default                = 'html response, default form';
-		$form_html_mini                   = 'html response mini, non-default form';
-		$form_html_mini_default           = 'html response mini, default form';
 
-		// Mock form_definition coming from api, non-default form.
-		$form_definition = $this->mock_form_definition();
-
-		// Mock form_definition coming from api, default form.
-		$form_definition_default = $this->mock_form_definition();
-
-		// Mock minified form definition, non-default form.
-		$minified_form_definition = $this->mock_form_definition();
-
-		// Mock minified form definition, default form.
+		$form_definition                  = $this->mock_form_definition();
+		$form_definition_default          = $this->mock_form_definition();
+		$minified_form_definition         = $this->mock_form_definition();
 		$minified_form_definition_default = $this->mock_form_definition();
+
+		$form_html              = 'html response, non-default form';
+		$form_html_default      = 'html response, default form';
+		$form_html_mini         = 'html response mini, non-default form';
+		$form_html_mini_default = 'html response mini, default form';
 
 		$form = $this->getMockBuilder( Inquiry_Form::class )
 						->setConstructorArgs( [ $this->spectrum ] )

--- a/vendor/composer/ClassLoader.php
+++ b/vendor/composer/ClassLoader.php
@@ -379,9 +379,9 @@ class ClassLoader
                 $subPath = substr($subPath, 0, $lastPos);
                 $search = $subPath.'\\';
                 if (isset($this->prefixDirsPsr4[$search])) {
+                    $pathEnd = DIRECTORY_SEPARATOR . substr($logicalPathPsr4, $lastPos + 1);
                     foreach ($this->prefixDirsPsr4[$search] as $dir) {
-                        $length = $this->prefixLengthsPsr4[$first][$search];
-                        if (file_exists($file = $dir . DIRECTORY_SEPARATOR . substr($logicalPathPsr4, $length))) {
+                        if (file_exists($file = $dir . $pathEnd)) {
                             return $file;
                         }
                     }

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -10,5 +10,6 @@ return array(
     'BU\\Plugins\\Liaison_Inquiry\\Inquiry_Form' => $baseDir . '/includes/class-inquiry-form.php',
     'BU\\Plugins\\Liaison_Inquiry\\Plugin' => $baseDir . '/includes/class-plugin.php',
     'BU\\Plugins\\Liaison_Inquiry\\Sample_Spectrum_API' => $baseDir . '/includes/class-sample-spectrum-api.php',
+    'BU\\Plugins\\Liaison_Inquiry\\Settings' => $baseDir . '/includes/class-settings.php',
     'BU\\Plugins\\Liaison_Inquiry\\Spectrum_API' => $baseDir . '/includes/class-spectrum-api.php',
 );

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -11,6 +11,7 @@ class ComposerStaticInit83a43bff8caa94ded7a01ab7f29fe114
         'BU\\Plugins\\Liaison_Inquiry\\Inquiry_Form' => __DIR__ . '/../..' . '/includes/class-inquiry-form.php',
         'BU\\Plugins\\Liaison_Inquiry\\Plugin' => __DIR__ . '/../..' . '/includes/class-plugin.php',
         'BU\\Plugins\\Liaison_Inquiry\\Sample_Spectrum_API' => __DIR__ . '/../..' . '/includes/class-sample-spectrum-api.php',
+        'BU\\Plugins\\Liaison_Inquiry\\Settings' => __DIR__ . '/../..' . '/includes/class-settings.php',
         'BU\\Plugins\\Liaison_Inquiry\\Spectrum_API' => __DIR__ . '/../..' . '/includes/class-spectrum-api.php',
     );
 


### PR DESCRIPTION
Adds new settings to the admin panel: UTM settings.

These settings represent a list of fields that will be automatically filled by the backend based on the get parameters of the current URL.

Example:
- UTM Source has value of 10.
- Inquiry form contains a field with ID 10 and also fields with IDs 1 and 2.
- Inquiry form located at https://site.com/inquiry

When the user visits https://site.com/inquiry/?utm_source=google , there will be only 2 fields (IDs 1 and 2). After the user fills them out and clicks the submit button, the form submission will look like `1=value1&2=value2&10=google`

When the user visits https://site.com/inquiry , there will be only 2 fields, and form submissions will look like `1=value1&2=value2&10=`